### PR TITLE
Retry an initial channel produce failure

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -466,20 +466,30 @@ function Channel (base, options) {
    *   `operationCallback` is an object containing the `result` from the last
    *   operation attempt (or `null` if the operation was stopped prior to a
    *   final attempt).
+   * @param {Number} [maxRetries] - Maximum number of retries to attempt in
+   *   the event of a failure. If no value is specified for this parameter,
+   *   retries will be performed continuously until the operation succeeds or
+   *   one of the terminal conditions mentioned above occurs.
    * @private
    */
-  this._retryOnFailure = function (operationCallback, completeCallback) {
+  this._retryOnFailure = function (operationCallback, completeCallback,
+                                   maxRetries) {
     if (!operationCallback) {
       if (completeCallback) {
         callbackAsync(completeCallback)
       }
     } else if (this._stillActive(completeCallback)) {
-      var operation = retry.operation({
+      var operationParams = {
         factor: RETRY_FACTOR,
-        forever: true,
         minTimeout: MIN_RETRY_TIMEOUT,
         maxTimeout: MAX_RETRY_TIMEOUT
-      })
+      }
+      if (typeof maxRetries === 'undefined') {
+        operationParams.forever = true
+      } else {
+        operationParams.retries = maxRetries
+      }
+      var operation = retry.operation(operationParams)
 
       operation.attempt(function () {
         if (channel._stillActive(completeCallback)) {
@@ -1086,22 +1096,27 @@ Channel.prototype.delete = function (callback) {
  *   received from the streaming service for the produce attempt.
  */
 Channel.prototype.produce = function (payload, callback) {
-  this._sendRequest(
-    this._request.post,
-    {
-      uri: util.appendUrlSubpath(this._producerPathPrefix, 'produce'),
-      json: true,
-      body: payload,
-      headers: {
-        'Content-Type': 'application/vnd.dxl.intel.records.v1+json'
-      }
+  var channel = this
+  this._retryOnFailure(
+    function (retryCallback) {
+      channel._sendRequest(
+        channel._request.post,
+        {
+          uri: util.appendUrlSubpath(channel._producerPathPrefix, 'produce'),
+          json: true,
+          body: payload,
+          headers: {
+            'Content-Type': 'application/vnd.dxl.intel.records.v1+json'
+          }
+        },
+        function () {
+          retryCallback(null)
+        },
+        retryCallback
+      )
     },
-    function () {
-      if (callback) {
-        callback(null)
-      }
-    },
-    callback
+    callback,
+    1
   )
 }
 


### PR DESCRIPTION
Previously, if a call to the channel `produce` method were to fail due
to the channel token having expired, no attempt was made to
automatically re-authenticate, attempt to obtain a new token, and
repeat the call to the `produce` method.

With the changes in this commit, an initial failure in a call to the
`produce` method will be retried, with an attempt made to
re-authenticate and obtain a new token before the second attempt to
perform the `produce` call. An error is delivered to the `produce`
callback if consecutive calls fail.