### PR TITLE
Bug fix for allowing non-json payloads

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -851,8 +851,7 @@ Channel.prototype.consume = function (callback) {
               partition: record.partition,
               offset: record.offset
             })
-            payloads.push(JSON.parse(Buffer.from(record.message.payload,
-              'base64')))
+            payloads.push(Buffer.from(record.message.payload,'base64').toString())
           })
           retryCallback(null, payloads)
         },

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -851,7 +851,7 @@ Channel.prototype.consume = function (callback) {
               partition: record.partition,
               offset: record.offset
             })
-            payloads.push(Buffer.from(record.message.payload,'base64').toString())
+            payloads.push(Buffer.from(record.message.payload, 'base64').toString())
           })
           retryCallback(null, payloads)
         },


### PR DESCRIPTION
Avoids exception if payload is not JSON. According to DXL Streaming spec, payload can be anything.